### PR TITLE
[FIX] reverting change to length of gpudrive scenarios

### DIFF
--- a/scenariomax/unified_to_gpudrive/build_gpudrive_example.py
+++ b/scenariomax/unified_to_gpudrive/build_gpudrive_example.py
@@ -10,7 +10,6 @@ from scenariomax.unified_to_gpudrive.utils import convert_numpy
 
 
 ERR_VAL = -1e4
-DEFAULT_MAX_SCENARIO_LENGTH = 201
 ### BEGIN CODE ADAPTED FROM GPUDRIVE https://github.com/Emerge-Lab/gpudrive/blob/main/data_utils/process_waymo_files.py
 
 
@@ -231,18 +230,13 @@ def _convert_map_features(scenario_net_map_features):
 def _ensure_scalar(value):
     return value.item() if isinstance(value, np.ndarray) and value.size == 1 else value
 
-def _pad_to_length(arr, pad_value=0):
-    full = np.ones((DEFAULT_MAX_SCENARIO_LENGTH, *arr.shape[1:])) * pad_value
-    full[:len(arr)] = arr
-    return full
-
 def _extract_obj(index, object_id, scenario_net_object):
     state = scenario_net_object["state"]
     metadata = scenario_net_object["metadata"]
-    valids = _pad_to_length(state["valid"], False)
-    positions = _pad_to_length(state["position"])
-    headings = _pad_to_length(state["heading"])
-    velocities = _pad_to_length(state["velocity"])
+    valids = state["valid"]
+    positions = state["position"]
+    headings = state["heading"]
+    velocities = state["velocity"]
 
     position = [
         {"x": point[0], "y": point[1], "z": point[2]} if valids[index] else {"x": ERR_VAL, "y": ERR_VAL, "z": ERR_VAL}


### PR DESCRIPTION
It turns out this was not necessary, may be causing a bug. 

I will merge this PR after I confirm that there are no longer issues with the scenarios.