### PR TITLE
[DEV] TL states for gpudrive + avg. dist per object

### DIFF
--- a/scenariomax/unified_to_gpudrive/data/map_element_ids.py
+++ b/scenariomax/unified_to_gpudrive/data/map_element_ids.py
@@ -64,3 +64,11 @@ TYPE_TO_MAP_FEATURE_NAME = {
 }
 
 FILTERED_TYPES = ["TRAFFIC_CONE", "TRAFFIC_BARRIER"]
+
+TRAFFIC_LIGHT_STATES_MAP = {
+    # the light states above will be converted to the following 4 types
+    "TRAFFIC_LIGHT_UNKNOWN": "unknown",
+    "TRAFFIC_LIGHT_RED": "stop",
+    "TRAFFIC_LIGHT_YELLOW": "caution",
+    "TRAFFIC_LIGHT_GREEN": "go",
+}


### PR DESCRIPTION
TL states are being added to GPUDrive, so we should support them in the conversion script.

Also added some additional information to help debug scenes, the distance traveled per agent, and average distance traveled per scene, as it seems like many nuPlan scenes have limited movement.